### PR TITLE
[deadline: 2024-12-01 00:00:00 UTC] Update Porkbun API domain root to api.porkbun.com

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ Python client for the Porkbun API
 ### About
 
 *pkb_client* is an python client for the [Porkbun](https://porkbun.com) API. It supports the v3 of the API. You can
-find the official documentation of the Porkbun API [here](https://porkbun.com/api/json/v3/documentation).
+find the official documentation of the Porkbun API [here](https://api.porkbun.com/api/json/v3/documentation).
 
 ### Installation
 
@@ -57,7 +57,7 @@ pip3 install .
 ### Usage
 
 Each request must be made with the API key and secret. You can easily create them at Porkbun. Just follow
-the [official instructions](https://porkbun.com/api/json/v3/documentation#Authentication). Make sure that you explicitly
+the [official instructions](https://api.porkbun.com/api/json/v3/documentation#Authentication). Make sure that you explicitly
 activate the API usage for your domain at the end. There are two ways to use `pkb_client`. The first way is to use it as
 a Python module. See the [module documentation](https://infinityofspace.github.io/pkb_client) for more information. The
 second way is to use the module from the command line, see below for more information.
@@ -134,7 +134,7 @@ pkb-client -k <YOUR-API-KEY> -s <YOUR-API-SECRET> dns-import example.com dns_rec
 ### Notes
 
 Currently, TTL smaller than `600` are ignored by the Porkbun API and the minimum value is `600`, although a minimum
-value of `300` is [supported](https://porkbun.com/api/json/v3/documentation) and allowed by the RFC standard. However,
+value of `300` is [supported](https://api.porkbun.com/api/json/v3/documentation) and allowed by the RFC standard. However,
 you can do TTL smaller than `600` via the web dashboard.
 
 ### Third party notices

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ About
 =====
 
 *pkb_client* is an python client for the `Porkbun <https://porkbun.com>`_ API. It supports the v3 of the API. You can
-find the official documentation of the Porkbun API `here <https://porkbun.com/api/json/v3/documentation>`_.
+find the official documentation of the Porkbun API `here <https://api.porkbun.com/api/json/v3/documentation>`_.
 
 *Note:* This project is not associated with Porkbun LLC.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,7 +14,7 @@ To use the PKB client, you need to create an instance of the :class:`PKBClient <
     pkb = PKBClient(
         api_key="<your-api-key>",
         secret_api_key="<your-secret-api-key>",
-        api_endpoint="https://porkbun.com/api/json/v3",
+        api_endpoint="https://api.porkbun.com/api/json/v3",
     )
 
 Whereby the api_key and secret_api_key are optional and only required if you want to use the PKB API with API endpoints

--- a/pkb_client/client/client.py
+++ b/pkb_client/client/client.py
@@ -13,7 +13,7 @@ from pkb_client.client.domain import DomainInfo
 from pkb_client.client.forwarding import URLForwarding, URLForwardingType
 from pkb_client.client.ssl_cert import SSLCertBundle
 
-API_ENDPOINT = "https://porkbun.com/api/json/v3/"
+API_ENDPOINT = "https://api.porkbun.com/api/json/v3/"
 
 # prevent urllib3 to log request with the api key and secret
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -65,7 +65,7 @@ class PKBClient:
     def ping(self, **kwargs) -> str:
         """
         API ping method: get the current public ip address of the requesting system; can also be used for auth checking.
-        See https://porkbun.com/api/json/v3/documentation#Authentication for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#Authentication for more info.
 
         :return: the current public ip address of the requesting system
         """
@@ -90,7 +90,7 @@ class PKBClient:
                    prio: Optional[int] = None, **kwargs) -> str:
         """
         API DNS create method: create a new DNS record for given domain.
-        See https://porkbun.com/api/json/v3/documentation#DNS%20Create%20Record for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#DNS%20Create%20Record for more info.
 
         :param domain: the domain for which the DNS record should be created
         :param record_type: the type of the new DNS record
@@ -137,7 +137,7 @@ class PKBClient:
                  **kwargs) -> bool:
         """
         API DNS edit method: edit an existing DNS record specified by the id for a given domain.
-        See https://porkbun.com/api/json/v3/documentation#DNS%20Edit%20Record for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#DNS%20Edit%20Record for more info.
 
         :param domain: the domain for which the DNS record should be edited
         :param record_id: the id of the DNS record which should be edited
@@ -184,7 +184,7 @@ class PKBClient:
                      prio: Optional[int] = None, **kwargs) -> bool:
         """
         API DNS edit method: edit all existing DNS record matching the domain, record type and subdomain.
-        See https://porkbun.com/api/json/v3/documentation#DNS%20Edit%20Record%20by%20Domain,%20Subdomain%20and%20Type for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#DNS%20Edit%20Record%20by%20Domain,%20Subdomain%20and%20Type for more info.
 
         :param domain: the domain for which the DNS record should be edited
         :param record_type: the type of the DNS record
@@ -225,7 +225,7 @@ class PKBClient:
                    **kwargs) -> bool:
         """
         API DNS delete method: delete an existing DNS record specified by the id for a given domain.
-        See https://porkbun.com/api/json/v3/documentation#DNS%20Delete%20Record for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#DNS%20Delete%20Record for more info.
 
         :param domain: the domain for which the DNS record should be deleted
         :param record_id: the id of the DNS record which should be deleted
@@ -251,7 +251,7 @@ class PKBClient:
                        **kwargs) -> bool:
         """
         API DNS delete method: delete all existing DNS record matching the domain, record type and subdomain.
-        See https://porkbun.com/api/json/v3/documentation#DNS%20Delete%20Records%20by%20Domain,%20Subdomain%20and%20Type for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#DNS%20Delete%20Records%20by%20Domain,%20Subdomain%20and%20Type for more info.
 
         :param domain: the domain for which the DNS record should be deleted
         :param record_type: the type of the DNS record
@@ -275,7 +275,7 @@ class PKBClient:
         """
         API DNS retrieve method: retrieve all DNS records for given domain if no record id is specified.
         Otherwise, retrieve the DNS record of the specified domain with the given record id.
-        See https://porkbun.com/api/json/v3/documentation#DNS%20Retrieve%20Records for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#DNS%20Retrieve%20Records for more info.
 
         :param domain: the domain for which the DNS records should be retrieved
         :param record_id: the id of the DNS record which should be retrieved
@@ -304,7 +304,7 @@ class PKBClient:
                          **kwargs) -> List[DNSRecord]:
         """
         API DNS retrieve method: retrieve all DNS records matching the domain, record type and subdomain.
-        See https://porkbun.com/api/json/v3/documentation#DNS%20Retrieve%20Records%20by%20Domain,%20Subdomain%20and%20Type for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#DNS%20Retrieve%20Records%20by%20Domain,%20Subdomain%20and%20Type for more info.
 
         :param domain: the domain for which the DNS records should be retrieved
         :param record_type: the type of the DNS records
@@ -562,7 +562,7 @@ class PKBClient:
     def update_dns_servers(self, domain: str, name_servers: List[str], **kwargs) -> bool:
         """
         Update the name servers of the specified domain.
-        See https://porkbun.com/api/json/v3/documentation#Domain%20Update%20Name%20Servers for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#Domain%20Update%20Name%20Servers for more info.
 
         :return: True if everything went well
         """
@@ -584,7 +584,7 @@ class PKBClient:
     def get_dns_servers(self, domain: str, **kwargs) -> List[str]:
         """
         Get the name servers for the given domain.
-        See https://porkbun.com/api/json/v3/documentation#Domain%20Get%20Name%20Servers for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#Domain%20Get%20Name%20Servers for more info.
 
         :return: list of name servers
         """
@@ -603,7 +603,7 @@ class PKBClient:
     def list_domains(self, start: int = 0, **kwargs) -> List[DomainInfo]:
         """
         Get all domains for the account in chunks of 1000. If you reach the end of all domains, the list will be empty.
-        See https://porkbun.com/api/json/v3/documentation#Domain%20List%20All for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#Domain%20List%20All for more info.
 
         :param start: the index of the first domain to retrieve
 
@@ -628,7 +628,7 @@ class PKBClient:
     def get_url_forward(self, domain: str, **kwargs) -> List[URLForwarding]:
         """
         Get the url forwarding for the given domain.
-        See https://porkbun.com/api/json/v3/documentation#Domain%20Get%20URL%20Forwarding for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#Domain%20Get%20URL%20Forwarding for more info.
 
         :return: list of URLForwarding objects
         """
@@ -653,8 +653,8 @@ class PKBClient:
                         wildcard: bool,
                         **kwargs) -> bool:
         """
-        Add an url forward for the given domain.
-        See https://porkbun.com/api/json/v3/documentation#Domain%20Add%20URL%20Forward for more info.
+        Add a url forward for the given domain.
+        See https://api.porkbun.com/api/json/v3/documentation#Domain%20Add%20URL%20Forward for more info.
 
         :param domain: the domain for which the url forwarding should be added
         :param subdomain: the subdomain for which the url forwarding should be added, can be empty for root domain
@@ -687,7 +687,7 @@ class PKBClient:
     def delete_url_forward(self, domain: str, id: str, **kwargs) -> bool:
         """
         Delete an url forward for the given domain.
-        See https://porkbun.com/api/json/v3/documentation#Domain%20Delete%20URL%20Forward for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#Domain%20Delete%20URL%20Forward for more info.
 
         :param domain: the domain for which the url forwarding should be deleted
         :param id: the id of the url forwarding which should be deleted
@@ -709,7 +709,7 @@ class PKBClient:
     def get_domain_pricing(self, **kwargs) -> dict:
         """
         Get the pricing for all Porkbun domains.
-        See https://porkbun.com/api/json/v3/documentation#Domain%20Pricing for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#Domain%20Pricing for more info.
 
         :return: dict with pricing
         """
@@ -727,7 +727,7 @@ class PKBClient:
     def ssl_retrieve(self, domain, **kwargs) -> SSLCertBundle:
         """
         API SSL bundle retrieve method: retrieve an SSL bundle for the given domain.
-        See https://porkbun.com/api/json/v3/documentation#SSL%20Retrieve%20Bundle%20by%20Domain for more info.
+        See https://api.porkbun.com/api/json/v3/documentation#SSL%20Retrieve%20Bundle%20by%20Domain for more info.
 
         :param domain: the domain for which the SSL bundle should be retrieved
 


### PR DESCRIPTION
Ran tests locally and all cleared.

This or a similar fix should be merged before **2024-12-01 00:00:00 UTC**.

Updates all API domain roots from `porkbun.com` to `api.porkbun.com` as per notice from Porkbun today:

> The reason you are receiving this email is because you have an API key associated with your account. In order to ensure that any apps or tools you may have that utilize our API, we wanted to let you know about some upcoming critical updates.
> 
> We know these kinds of changes are annoying but the time has come to separate the processing of incoming API commands from our website. In previous documentation the hostname porkbun.com was used for the API but we have recently updated it to api.porkbun.com and in the near future will start enforcing its use. Please update the hostname for our API to api.porkbun.com as soon as possible.
> 
> CRITICAL UPDATE DETAILS
> 
> Type: API Hostname Change
> 
> Old Value: porkbun.com
> 
> New Value: api.porkbun.com
> 
> Deadline: 2024-12-01 00:00:00 UTC
> 
> Please note that after the deadline, API calls made to the old hostname will no longer be allowed. If you have any questions or concerns please contact support.